### PR TITLE
선호도 설정 구현

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,7 +39,7 @@ allprojects {
 android {
 //    compileSdkVersion flutter.compileSdkVersion
     compileSdkVersion 31
-    ndkVersion flutter.ndkVersion
+    // ndkVersion flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -60,7 +60,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
 //        minSdkVersion flutter.minSdkVersion
-        minSdkVersion 30
+        minSdkVersion 31
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
@@ -87,7 +87,7 @@ dependencies {
 
 android {
     defaultConfig {
-        minSdkVersion 30
+        minSdkVersion 31
     }
     compileSdkVersion 31
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.staya.asap_client">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- 2. To overcome bind to recognition service failed issue -->
+    <queries>
+        <package android:name="com.google.android.googlequicksearchbox"/>
+    </queries>
+
    <application
         android:label="asap_client"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,10 @@
-import 'dart:convert';
-import 'dart:async';
 import 'package:asap_client/screen/screen_setting.dart';
 import 'package:asap_client/screen/screen_voice1.dart';
 import 'package:flutter/material.dart';
-import 'package:asap_client/model/model_user.dart';
 import 'package:asap_client/provider/provider_user.dart';
-import 'package:asap_client/screen/screen_navi.dart';
 
 import 'package:asap_client/screen/screen_sign_up.dart';
 import 'package:asap_client/screen/screen_login.dart';
-import 'package:asap_client/screen/screen_selection.dart';
-import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:kakao_flutter_sdk_common/kakao_flutter_sdk_common.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_navi.dart';
@@ -34,7 +28,7 @@ void main() async {
       child: MyApp()));
 }
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({key});
 
   // This widget is the root of your application.
   @override
@@ -51,7 +45,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+  const MyHomePage({key, required this.title});
 
   final String title;
 

--- a/lib/provider/provider_user.dart
+++ b/lib/provider/provider_user.dart
@@ -8,6 +8,7 @@ class UserProvider extends ChangeNotifier {
   double _costPrefer = 0;
   bool _canMechanical = true;
   bool _canNarrow = true;
+  String _token = "";
 
   String get email => _email;
   String get password => _password;
@@ -16,6 +17,7 @@ class UserProvider extends ChangeNotifier {
   double get costPrefer => _costPrefer;
   bool get canMechanical => _canMechanical;
   bool get canNarrow => _canNarrow;
+  String get token => _token;
 
   set email(String inputEmail) {
     _email = inputEmail;
@@ -49,6 +51,11 @@ class UserProvider extends ChangeNotifier {
 
   set canNarrow(bool inputCanNarrow) {
     _canNarrow = inputCanNarrow;
+    notifyListeners();
+  }
+
+  set token(String inputToken) {
+    _token = inputToken;
     notifyListeners();
   }
 }

--- a/lib/provider/provider_user.dart
+++ b/lib/provider/provider_user.dart
@@ -4,23 +4,51 @@ class UserProvider extends ChangeNotifier {
   String _email = "";
   String _password = "";
   String _name = "";
+  double _distPrefer = 0;
+  double _costPrefer = 0;
+  bool _canMechanical = true;
+  bool _canNarrow = true;
 
   String get email => _email;
   String get password => _password;
   String get name => _name;
+  double get distPrefer => _distPrefer;
+  double get costPrefer => _costPrefer;
+  bool get canMechanical => _canMechanical;
+  bool get canNarrow => _canNarrow;
 
-  void set email(String input_email) {
-    _email = input_email;
+  set email(String inputEmail) {
+    _email = inputEmail;
     notifyListeners();
   }
 
-  void set password(String input_password) {
-    _password = input_password;
+  set password(String inputPassword) {
+    _password = inputPassword;
     notifyListeners();
   }
 
-  void set name(String input_name) {
-    _name = input_name;
+  set name(String inputName) {
+    _name = inputName;
+    notifyListeners();
+  }
+
+  set distPrefer(double inputDistPrefer) {
+    _distPrefer = inputDistPrefer;
+    notifyListeners();
+  }
+
+  set costPrefer(double inputCostPrefer) {
+    _costPrefer = inputCostPrefer;
+    notifyListeners();
+  }
+
+  set canMechanical(bool inputCanMechanical) {
+    _canMechanical = inputCanMechanical;
+    notifyListeners();
+  }
+
+  set canNarrow(bool inputCanNarrow) {
+    _canNarrow = inputCanNarrow;
     notifyListeners();
   }
 }

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -19,15 +19,16 @@ class _LoginPageState extends State<LoginPage> {
   late double height;
   late UserProvider _userProvider;
 
-  final _emailErrorMsg = '';
-  final _passwordErrorMsg = '';
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
 
   Future<bool> _submit() async {
     var url = Uri.parse('http://10.0.2.2:8080/api/auth/signin/');
 
-    final logInBody = {'email': 'user@test.com', 'password': '12345678'};
+    final logInBody = {
+      'email': _emailController.text,
+      'password': _passwordController.text
+    };
 
     var response = await http.post(url,
         body: json.encode(logInBody),
@@ -80,12 +81,12 @@ class _LoginPageState extends State<LoginPage> {
                   margin: EdgeInsets.fromLTRB(
                       _marginInputForm, 170, _marginInputForm, 0),
                   child: _inputForm(
-                      "이메일", _emailController, _emailErrorMsg, width)),
+                      "이메일", _emailController, width)),
               Container(
                   margin: EdgeInsets.fromLTRB(
                       _marginInputForm, 20, _marginInputForm, 0),
                   child: _inputForm(
-                      "비밀번호", _passwordController, _passwordErrorMsg, width)),
+                      "비밀번호", _passwordController, width)),
               const SizedBox(height: 80.0),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
@@ -116,35 +117,18 @@ class _LoginPageState extends State<LoginPage> {
 }
 
 Widget _inputForm(String type, TextEditingController textEditingController,
-    String errorMsg, double width) {
+    double width) {
   final TextFormField textFormField;
   if ("이메일" == type) {
     textFormField = TextFormField(
       keyboardType: TextInputType.emailAddress,
       controller: textEditingController,
-      decoration: InputDecoration(
-        label: Text(
-          errorMsg,
-          style: const TextStyle(color: Colors.red, fontSize: 14),
-        ),
-      ),
     );
-  } else if ("이름" == type) {
-    textFormField = TextFormField(
-      keyboardType: TextInputType.name,
-      controller: textEditingController,
-    );
-  } else if ("비밀번호" == type || "비밀번호 확인" == type) {
+  } else if ("비밀번호" == type) {
     textFormField = TextFormField(
       obscureText: true,
       keyboardType: TextInputType.visiblePassword,
       controller: textEditingController,
-      decoration: InputDecoration(
-        label: Text(
-          errorMsg,
-          style: const TextStyle(color: Colors.red, fontSize: 13),
-        ),
-      ),
     );
   } else {
     throw Exception("[ERROR] Invalid argument in _inputForm");

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:asap_client/provider/provider_user.dart';
 import 'package:flutter/material.dart';
 import 'package:asap_client/screen/screen_sign_up.dart';
 import 'package:asap_client/screen/screen_welcome.dart';
@@ -16,64 +17,91 @@ class _LoginPageState extends State<LoginPage> {
   late Size screenSize;
   late double width;
   late double height;
+  late UserProvider _userProvider;
+
   final _emailErrorMsg = '';
   final _passwordErrorMsg = '';
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
 
-  void _callAPI() async {
+  Future<bool> _submit() async {
+    var url = Uri.parse('http://10.0.2.2:8080/api/auth/signin/');
 
-    var url = Uri.parse('http://staya.koreacentral.cloudapp.azure.com:8080/api/auth/signin');
-    Map data1 = {
-      'email': 'user@test.com',
-      'password': '12345678'
-    };
-    var response = await http.post(url, body: json.encode(data1), headers: {
-      'Content-Type': 'application/json'
-    });
-    String token = response.body.toString();
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    final logInBody = {'email': 'user@test.com', 'password': '12345678'};
 
-    Navigator.push(context,
-        MaterialPageRoute(builder: (context) => Welcome()));
+    var response = await http.post(url,
+        body: json.encode(logInBody),
+        headers: {'Content-Type': 'application/json'});
+
+    if (response.statusCode != 200) {
+      return false;
+    }
+
+    _userProvider.token = response.body.toString();
+    return true;
   }
 
+  Future<void> alertLogInFail() async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("로그인 실패"),
+          content: const Text("이메일 또는 비밀번호를 다시 확인해주세요"),
+          actions: <Widget>[
+            ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text("확인"))
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     screenSize = MediaQuery.of(context).size;
     width = screenSize.width;
     height = screenSize.height;
+    _userProvider = Provider.of<UserProvider>(context);
+
     final _marginInputForm = width * 0.09;
     return SafeArea(
       child: Scaffold(
         appBar: AppBar(
           title: const Text('LOG IN'),
         ),
-
         body: SafeArea(
           child: ListView(
             padding: const EdgeInsets.symmetric(horizontal: 24.0),
             children: <Widget>[
-
               Container(
-                  margin: EdgeInsets.fromLTRB(_marginInputForm, 170, _marginInputForm, 0),
+                  margin: EdgeInsets.fromLTRB(
+                      _marginInputForm, 170, _marginInputForm, 0),
                   child: _inputForm(
                       "이메일", _emailController, _emailErrorMsg, width)),
               Container(
-                  margin: EdgeInsets.fromLTRB(_marginInputForm, 20, _marginInputForm, 0),
-                  child: _inputForm("비밀번호", _passwordController,
-                      _passwordErrorMsg, width)),
+                  margin: EdgeInsets.fromLTRB(
+                      _marginInputForm, 20, _marginInputForm, 0),
+                  child: _inputForm(
+                      "비밀번호", _passwordController, _passwordErrorMsg, width)),
               const SizedBox(height: 80.0),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   padding: EdgeInsets.symmetric(vertical: height * 0.02),
-                  minimumSize: Size(width*0.5, height*0.015),
+                  minimumSize: Size(width * 0.5, height * 0.015),
                 ),
-                // onPressed: () => Navigator.push(context,
-                //     MaterialPageRoute(builder: (context) => Welcome())),
-                onPressed: _callAPI,
+                onPressed: () async {
+                  await _submit().then((value) {
+                    if (value == true) {
+                      Navigator.push(context,
+                          MaterialPageRoute(builder: (context) => Welcome()));
+                    } else {
+                      alertLogInFail();
+                    }
+                  });
+                },
                 child: const Text(
                   '로그인',
                   style: TextStyle(fontSize: 18),

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -17,15 +17,16 @@ class _LoginPageState extends State<LoginPage> {
   late double height;
   late UserProvider _userProvider;
 
-  final _emailErrorMsg = '';
-  final _passwordErrorMsg = '';
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
 
   Future<bool> _submit() async {
     var url = Uri.parse('http://10.0.2.2:8080/api/auth/signin/');
 
-    final logInBody = {'email': 'user@test.com', 'password': '12345678'};
+    final logInBody = {
+      'email': _emailController.text,
+      'password': _passwordController.text
+    };
 
     var response = await http.post(url,
         body: json.encode(logInBody),
@@ -78,12 +79,12 @@ class _LoginPageState extends State<LoginPage> {
                   margin: EdgeInsets.fromLTRB(
                       _marginInputForm, 170, _marginInputForm, 0),
                   child: _inputForm(
-                      "이메일", _emailController, _emailErrorMsg, width)),
+                      "이메일", _emailController, width)),
               Container(
                   margin: EdgeInsets.fromLTRB(
                       _marginInputForm, 20, _marginInputForm, 0),
                   child: _inputForm(
-                      "비밀번호", _passwordController, _passwordErrorMsg, width)),
+                      "비밀번호", _passwordController, width)),
               const SizedBox(height: 80.0),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
@@ -114,35 +115,18 @@ class _LoginPageState extends State<LoginPage> {
 }
 
 Widget _inputForm(String type, TextEditingController textEditingController,
-    String errorMsg, double width) {
+    double width) {
   final TextFormField textFormField;
   if ("이메일" == type) {
     textFormField = TextFormField(
       keyboardType: TextInputType.emailAddress,
       controller: textEditingController,
-      decoration: InputDecoration(
-        label: Text(
-          errorMsg,
-          style: const TextStyle(color: Colors.red, fontSize: 14),
-        ),
-      ),
     );
-  } else if ("이름" == type) {
-    textFormField = TextFormField(
-      keyboardType: TextInputType.name,
-      controller: textEditingController,
-    );
-  } else if ("비밀번호" == type || "비밀번호 확인" == type) {
+  } else if ("비밀번호" == type) {
     textFormField = TextFormField(
       obscureText: true,
       keyboardType: TextInputType.visiblePassword,
       controller: textEditingController,
-      decoration: InputDecoration(
-        label: Text(
-          errorMsg,
-          style: const TextStyle(color: Colors.red, fontSize: 13),
-        ),
-      ),
     );
   } else {
     throw Exception("[ERROR] Invalid argument in _inputForm");

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:asap_client/provider/provider_user.dart';
 import 'package:flutter/material.dart';
 import 'package:asap_client/screen/screen_welcome.dart';
 import 'package:http/http.dart' as http;
@@ -14,64 +15,91 @@ class _LoginPageState extends State<LoginPage> {
   late Size screenSize;
   late double width;
   late double height;
+  late UserProvider _userProvider;
+
   final _emailErrorMsg = '';
   final _passwordErrorMsg = '';
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
 
-  void _callAPI() async {
+  Future<bool> _submit() async {
+    var url = Uri.parse('http://10.0.2.2:8080/api/auth/signin/');
 
-    var url = Uri.parse('http://staya.koreacentral.cloudapp.azure.com:8080/api/auth/signin');
-    Map data1 = {
-      'email': 'user@test.com',
-      'password': '12345678'
-    };
-    var response = await http.post(url, body: json.encode(data1), headers: {
-      'Content-Type': 'application/json'
-    });
-    String token = response.body.toString();
-    print('Response status: ${response.statusCode}');
-    print('Response body: ${response.body}');
+    final logInBody = {'email': 'user@test.com', 'password': '12345678'};
 
-    Navigator.push(context,
-        MaterialPageRoute(builder: (context) => Welcome()));
+    var response = await http.post(url,
+        body: json.encode(logInBody),
+        headers: {'Content-Type': 'application/json'});
+
+    if (response.statusCode != 200) {
+      return false;
+    }
+
+    _userProvider.token = response.body.toString();
+    return true;
   }
 
+  Future<void> alertLogInFail() async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("로그인 실패"),
+          content: const Text("이메일 또는 비밀번호를 다시 확인해주세요"),
+          actions: <Widget>[
+            ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text("확인"))
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     screenSize = MediaQuery.of(context).size;
     width = screenSize.width;
     height = screenSize.height;
+    _userProvider = Provider.of<UserProvider>(context);
+
     final _marginInputForm = width * 0.09;
     return SafeArea(
       child: Scaffold(
         appBar: AppBar(
           title: const Text('LOG IN'),
         ),
-
         body: SafeArea(
           child: ListView(
             padding: const EdgeInsets.symmetric(horizontal: 24.0),
             children: <Widget>[
-
               Container(
-                  margin: EdgeInsets.fromLTRB(_marginInputForm, 170, _marginInputForm, 0),
+                  margin: EdgeInsets.fromLTRB(
+                      _marginInputForm, 170, _marginInputForm, 0),
                   child: _inputForm(
                       "이메일", _emailController, _emailErrorMsg, width)),
               Container(
-                  margin: EdgeInsets.fromLTRB(_marginInputForm, 20, _marginInputForm, 0),
-                  child: _inputForm("비밀번호", _passwordController,
-                      _passwordErrorMsg, width)),
+                  margin: EdgeInsets.fromLTRB(
+                      _marginInputForm, 20, _marginInputForm, 0),
+                  child: _inputForm(
+                      "비밀번호", _passwordController, _passwordErrorMsg, width)),
               const SizedBox(height: 80.0),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   padding: EdgeInsets.symmetric(vertical: height * 0.02),
-                  minimumSize: Size(width*0.5, height*0.015),
+                  minimumSize: Size(width * 0.5, height * 0.015),
                 ),
-                // onPressed: () => Navigator.push(context,
-                //     MaterialPageRoute(builder: (context) => Welcome())),
-                onPressed: _callAPI,
+                onPressed: () async {
+                  await _submit().then((value) {
+                    if (value == true) {
+                      Navigator.push(context,
+                          MaterialPageRoute(builder: (context) => Welcome()));
+                    } else {
+                      alertLogInFail();
+                    }
+                  });
+                },
                 child: const Text(
                   '로그인',
                   style: TextStyle(fontSize: 18),

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -6,6 +6,8 @@ import 'package:asap_client/screen/screen_welcome.dart';
 import 'package:http/http.dart' as http;
 import 'dart:ui';
 
+import 'package:provider/provider.dart';
+
 class LoginPage extends StatefulWidget {
   @override
   _LoginPageState createState() => _LoginPageState();

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:asap_client/screen/screen_sign_up.dart';
 import 'package:asap_client/screen/screen_welcome.dart';
-import 'package:provider/provider.dart';
 import 'package:http/http.dart' as http;
 import 'dart:ui';
 

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -63,7 +63,7 @@ class _LoginPageState extends State<LoginPage> {
                   margin: EdgeInsets.fromLTRB(_marginInputForm, 20, _marginInputForm, 0),
                   child: _inputForm("비밀번호", _passwordController,
                       _passwordErrorMsg, width)),
-              SizedBox(height: 80.0),
+              const SizedBox(height: 80.0),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   padding: EdgeInsets.symmetric(vertical: height * 0.02),

--- a/lib/screen/screen_login.dart
+++ b/lib/screen/screen_login.dart
@@ -65,7 +65,7 @@ class _LoginPageState extends State<LoginPage> {
                   margin: EdgeInsets.fromLTRB(_marginInputForm, 20, _marginInputForm, 0),
                   child: _inputForm("비밀번호", _passwordController,
                       _passwordErrorMsg, width)),
-              SizedBox(height: 80.0),
+              const SizedBox(height: 80.0),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   padding: EdgeInsets.symmetric(vertical: height * 0.02),

--- a/lib/screen/screen_navi.dart
+++ b/lib/screen/screen_navi.dart
@@ -26,6 +26,7 @@ class _NaviScreen extends State<NaviScreen> {
   late double height;
 
 
+
   @override
   Widget build(BuildContext context) {
 
@@ -85,40 +86,61 @@ class _NaviScreen extends State<NaviScreen> {
                 new Text("별점을 남겨주세요!"),
               ],
             ),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                RatingBar(
-                    initialRating: 0,
-                    direction: Axis.horizontal,
-                    allowHalfRating: true,
-                    itemCount: 5,
-                    ratingWidget: RatingWidget(
-                        full: const Icon(Icons.star, color: Colors.orange),
-                        half: const Icon(
-                          Icons.star_half,
-                          color: Colors.orange,
+            content:
+                Row(
+                  mainAxisSize: MainAxisSize.max,
+                  children: [
+                    Expanded(
+                      child: Padding(
+                        padding: EdgeInsetsDirectional.fromSTEB(0, 32, 0, 32),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.max,
+                          children: [
+                            Expanded(
+                              child: Padding(
+                                padding:
+                                EdgeInsetsDirectional.fromSTEB(0, 30, 0, 30),
+                                child: ElevatedButton.icon(
+                                  onPressed: () => {print("aa")},
+                                  icon: Icon(Icons.mood,size:18),
+                                  label: Text(
+                                    '만족해요!',
+                                    style: TextStyle(fontSize: 30, color: Colors.green),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
-                        empty: const Icon(
-                          Icons.star_outline,
-                          color: Colors.orange,
-                        )),
-                    onRatingUpdate: (value) {
-                      setState(() {
-                        _ratingValue = value;
-                      });
-                    }),
-              ],
-            ),
-            actions: <Widget>[
-              new TextButton(
-                  onPressed: (){
-                    Navigator.pop(context);
-                  },
-                  child: new Text("확인"),
-              ),
-            ],
+                      ),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: EdgeInsetsDirectional.fromSTEB(0, 32, 0, 32),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.max,
+                          children: [
+                            Expanded(
+                              child: Padding(
+                                padding:
+                                EdgeInsetsDirectional.fromSTEB(0, 30, 0, 30),
+                                child: ElevatedButton.icon(
+                                  onPressed: () => {print("aa")},
+                                  icon: Icon(Icons.mood_bad,size:18),
+                                  label:Text(
+                                    '별로예요',
+                                    style: TextStyle(fontSize: 30, color: Colors.green),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+
           );
         }
     );
@@ -130,4 +152,8 @@ class _NaviScreen extends State<NaviScreen> {
   }
 
 
+
+
+
 }
+

--- a/lib/screen/screen_navi.dart
+++ b/lib/screen/screen_navi.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:naver_map_plugin/naver_map_plugin.dart';
-import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 
 // Naver map LatLng 클래스
 class LocationClass extends LatLng {
@@ -10,7 +9,6 @@ class LocationClass extends LatLng {
   final double longitude;
   const LocationClass({required this.latitude, required this.longitude}) : super(latitude, longitude);
 }
-
 
 class NaviScreen extends StatefulWidget{
   @override

--- a/lib/screen/screen_selection.dart
+++ b/lib/screen/screen_selection.dart
@@ -1,10 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 import 'package:asap_client/main.dart';
-import 'package:asap_client/screen/screen_navi.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_rating_bar/flutter_rating_bar.dart';
-import 'package:provider/provider.dart';
 import 'package:kakao_flutter_sdk_common/kakao_flutter_sdk_common.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_navi.dart';
 
@@ -14,7 +11,7 @@ class SelectScreen extends StatefulWidget{
   final String yy;
   const SelectScreen(this.parking,this.xx, this.yy);
   State<StatefulWidget> createState() {
-    return _SelectScreen(this.parking,this.xx, this.yy);
+    return _SelectScreen(this.parking, this.xx, this.yy);
   }
 }
 
@@ -37,8 +34,7 @@ class _SelectScreen extends State<SelectScreen> {
     if (result) {
       print('카카오내비 앱으로 길안내 가능');
       await NaviApi.instance.navigate(
-        destination:
-        Location(name: '카카오 판교오피스', x: xx, y: yy),
+        destination: Location(name: '장소', x: yy, y: xx),
         option: NaviOption(coordType: CoordType.wgs84),
       );
     } else {

--- a/lib/screen/screen_selection.dart
+++ b/lib/screen/screen_selection.dart
@@ -10,9 +10,11 @@ import 'package:kakao_flutter_sdk/kakao_flutter_sdk_navi.dart';
 
 class SelectScreen extends StatefulWidget{
   final int parking;
-  const SelectScreen(this.parking);
+  final String xx;
+  final String yy;
+  const SelectScreen(this.parking,this.xx, this.yy);
   State<StatefulWidget> createState() {
-    return _SelectScreen(this.parking);
+    return _SelectScreen(this.parking,this.xx, this.yy);
   }
 }
 
@@ -22,17 +24,21 @@ class _SelectScreen extends State<SelectScreen> {
   late double width;
   late double height;
   int parking;
-  _SelectScreen(this.parking);
+  String xx = '';
+  String yy = '';
+  _SelectScreen(this.parking, this.xx, this.yy);
 
   // 카카오 내비 앱으로 전환
   void startNavi() async {
     // 카카오 API 연동
+    print(xx);
+    print(yy);
     bool result = await NaviApi.instance.isKakaoNaviInstalled();
     if (result) {
       print('카카오내비 앱으로 길안내 가능');
       await NaviApi.instance.navigate(
         destination:
-        Location(name: '카카오 판교오피스', x: '127.108640', y: '37.402111'),
+        Location(name: '카카오 판교오피스', x: xx, y: yy),
         option: NaviOption(coordType: CoordType.wgs84),
       );
     } else {
@@ -54,57 +60,151 @@ class _SelectScreen extends State<SelectScreen> {
           return AlertDialog(
 
             title: Column(
+              mainAxisSize: MainAxisSize.min,
               children: <Widget>[
                 new Text("안내받은 주차장은 어떠셨나요"),
                 new Text("별점을 남겨주세요!"),
               ],
             ),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                RatingBar(
-                    initialRating: 0,
-                    direction: Axis.horizontal,
-                    allowHalfRating: true,
-                    itemCount: 5,
-                    ratingWidget: RatingWidget(
-                        full: const Icon(Icons.star, color: Colors.orange),
-                        half: const Icon(
-                          Icons.star_half,
-                          color: Colors.orange,
+            content:
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children:<Widget> [
+
+                      Padding(
+                        padding: EdgeInsetsDirectional.fromSTEB(0, 30, 0, 30),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Expanded(
+                              child: Padding(
+                                padding:
+                                EdgeInsetsDirectional.fromSTEB(10, 30, 10, 30),
+                                child: ElevatedButton.icon(
+                                  onPressed: (){
+                                    Navigator.pop(context);
+                                    Navigator.push(context,
+                                        MaterialPageRoute(builder: (context) => MyHomePage(title:'')));
+                                  },
+                                  icon: Icon(Icons.mood,size:18),
+                                  label: Text(
+                                    '만족해요!',
+                                    style: TextStyle(fontSize: 20, color: Colors.white),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            Expanded(
+                              child: Padding(
+                                padding:
+                                EdgeInsetsDirectional.fromSTEB(10, 30, 10, 30),
+                                child: ElevatedButton.icon(
+                                  onPressed: () => {Review_Reason_Dialog()},
+                                  icon: Icon(Icons.mood_bad,size:18),
+                                  label:Text(
+                                    '별로예요',
+                                    style: TextStyle(fontSize: 20, color: Colors.white),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
-                        empty: const Icon(
-                          Icons.star_outline,
-                          color: Colors.orange,
-                        )),
-                    onRatingUpdate: (value) {
-                      setState(() {
-                        _ratingValue = value;
-                      });
-                    }),
+                      ),
+
               ],
             ),
-            actions: <Widget>[
-              new TextButton(
-                onPressed: (){
-                  Navigator.pop(context);
-                  Navigator.push(context,
-                      MaterialPageRoute(builder: (context) => MyHomePage(title:'')));
-                  },
-                child: new Text("확인"),
-              ),
-            ],
           );
         }
     );
   }
+
+  void Review_Reason_Dialog(){
+    double? _ratingValue;
+    showDialog(
+        context: context,
+        //barrierDismissible - Dialog를 제외한 다른 화면 터치 x
+        barrierDismissible: false,
+        builder: (BuildContext context){
+          return AlertDialog(
+
+            title: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                new Text("어떤점이 불만족스러우셨나요?")
+              ],
+            ),
+            content:
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children:<Widget> [
+
+                Padding(
+                  padding: EdgeInsetsDirectional.fromSTEB(0, 30, 0, 30),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Expanded(
+                        child: Padding(
+                          padding:
+                          EdgeInsetsDirectional.fromSTEB(10, 30, 10, 30),
+                          child: ElevatedButton.icon(
+                            onPressed: (){
+                              Navigator.pop(context);
+                              Navigator.push(context,
+                                  MaterialPageRoute(builder: (context) => MyHomePage(title:'')));
+                            },
+                            icon: Icon(Icons.directions_car_rounded,size:18),
+                            label: Text(
+                              '거리가 멀어요',
+                              style: TextStyle(fontSize: 20, color: Colors.white),
+                            ),
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Padding(
+                          padding:
+                          EdgeInsetsDirectional.fromSTEB(10, 30, 10, 30),
+                          child: ElevatedButton.icon(
+                            onPressed: (){
+                              Navigator.pop(context);
+                              Navigator.push(context,
+                                MaterialPageRoute(builder: (context) => MyHomePage(title:'')));},
+                            icon: Icon(Icons.attach_money_rounded,size:18),
+                            label:Text(
+                              '요금이 비싸요',
+                              style: TextStyle(fontSize: 20, color: Colors.white),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+              ],
+            ),
+          );
+        }
+    );
+  }
+
   void initState(){
     Timer(Duration(seconds:3), (){
       startNavi();
-      Timer(Duration(seconds:1), (){
-        ReviewDialog();
-      });
+      if(this.parking == 1) {
+        Timer(Duration(seconds: 1), () {
+          ReviewDialog();
+        });
+      }
+      else{
+        Navigator.pop(context);
+        Navigator.push(context,
+            MaterialPageRoute(builder: (context) => MyHomePage(title:'')));
+      }
     });
 
   }

--- a/lib/screen/screen_setting.dart
+++ b/lib/screen/screen_setting.dart
@@ -64,7 +64,7 @@ class _SettingScreen extends State<SettingScreen> {
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
       init(context.read<UserProvider>().token).then((_) => setState(() {}));
     });
   }

--- a/lib/screen/screen_setting.dart
+++ b/lib/screen/screen_setting.dart
@@ -1,12 +1,18 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:asap_client/main.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:http/http.dart' as http;
 
 import '../provider/provider_user.dart';
+import '../util/util_distance.dart';
+import '../util/util_cost.dart';
 
 class SettingScreen extends StatefulWidget {
+  @override
   State<StatefulWidget> createState() {
     return _SettingScreen();
   }
@@ -19,10 +25,49 @@ class _SettingScreen extends State<SettingScreen> {
 
   late UserProvider _userProvider;
 
-  late List<bool> isSelectedMechanical = [false, true];
-  late List<bool> isSelectedSmall = [false, true];
-  late List<bool> isSelectedDistance = [false, false, false, true];
-  late List<bool> isSelectedPrice = [false, false, false, true];
+  late List<bool> isSelectedMechanical = [false, false];
+  late List<bool> isSelectedSmall = [false, false];
+  late List<bool> isSelectedDistance = [false, false, false, false];
+  late List<bool> isSelectedPrice = [false, false, false, false];
+
+  Future<void> init(String token) async {
+    Uri patchUri = Uri.parse("http://10.0.2.2:8080/api/preference/");
+
+    final response = await http.get(patchUri, headers: {
+      HttpHeaders.authorizationHeader: token,
+      'content-type': 'application/json'
+    });
+
+    if (response.statusCode != 200) {
+      throw Exception("[ERROR] Can't get user preference from server");
+    }
+
+    final body = jsonDecode(response.body);
+
+    isSelectedDistance[getIndexOfDistance(body["dist_prefer"])] = true;
+    isSelectedPrice[getIndexOfCost(body["cost_prefer"])] = true;
+
+    if (body["can_mechanical"] == true) {
+      isSelectedMechanical[1] = true;
+    } else {
+      isSelectedMechanical[0] = true;
+    }
+
+    if (body["can_narrow"] == true) {
+      isSelectedSmall[1] = true;
+    } else {
+      isSelectedSmall[0] = true;
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      init(context.read<UserProvider>().token).then((_) => setState(() {}));
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,9 +77,25 @@ class _SettingScreen extends State<SettingScreen> {
 
     _userProvider = Provider.of<UserProvider>(context);
 
-    void _submit() {
-      Navigator.push(
-          context, MaterialPageRoute(builder: (context) => const MyApp()));
+    Future<bool> _submit() async {
+      Uri patchUri = Uri.parse("http://10.0.2.2:8080/api/preference/");
+
+      final body = jsonEncode({
+        "dist_prefer": getDistanceFromSelectedList(isSelectedDistance),
+        "cost_prefer": getCostFromSelectedList(isSelectedPrice),
+        "can_mechanical": (isSelectedMechanical[0] == false),
+        "can_narrow": (isSelectedSmall[0] == false),
+      });
+
+      final response = await http.patch(patchUri, body: body, headers: {
+        HttpHeaders.authorizationHeader: _userProvider.token,
+        'content-type': 'application/json'
+      });
+
+      if (response.statusCode != 200) {
+        return false;
+      }
+      return true;
     }
 
     final marginInputForm = width * 0.09;
@@ -51,11 +112,6 @@ class _SettingScreen extends State<SettingScreen> {
               textAlign: TextAlign.center,
               style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
-            // const Text(
-            //   '선호도를 알려주세요!',
-            //   textAlign: TextAlign.center,
-            //   style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-            // ),
             Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
@@ -77,22 +133,37 @@ class _SettingScreen extends State<SettingScreen> {
                 Container(
                   margin: EdgeInsets.fromLTRB(0, height * 0.03, 0, 0),
                   child: _inputPrefer2(
-                      "거리", "~0.5km", "~1km", "~1.5km", "상관 없어"),
+                      "거리",
+                      distanceToString(distances[0]),
+                      distanceToString(distances[1]),
+                      distanceToString(distances[2]),
+                      distanceToString(distances[3])),
                 ),
                 Container(
                   margin:
                       EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
-                  child:
-                      _inputPrefer2("요금", "무료만", "~500원", "~1000원", "상관 없어"),
+                  child: _inputPrefer2(
+                      "요금",
+                      costToString(costs[0]),
+                      costToString(costs[1]),
+                      costToString(costs[2]),
+                      costToString(costs[3])),
                 ),
               ],
             ),
             ElevatedButton(
               style: ElevatedButton.styleFrom(
                   padding: EdgeInsets.symmetric(vertical: height * 0.015)),
-              onPressed: () => _submit(),
+              onPressed: () async {
+                await _submit().then((isSubmitted) {
+                  if (isSubmitted = true) {
+                    Navigator.push(context,
+                        MaterialPageRoute(builder: (context) => const MyApp()));
+                  }
+                });
+              },
               child: const Text(
-                '확인',
+                '설정 저장하기',
                 style: TextStyle(fontSize: 18),
               ),
             ),

--- a/lib/screen/screen_setting.dart
+++ b/lib/screen/screen_setting.dart
@@ -1,13 +1,18 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:asap_client/main.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:asap_client/screen/screen_login.dart';
+import 'package:http/http.dart' as http;
 
 import '../provider/provider_user.dart';
+import '../util/util_distance.dart';
+import '../util/util_cost.dart';
 
 class SettingScreen extends StatefulWidget {
+  @override
   State<StatefulWidget> createState() {
     return _SettingScreen();
   }
@@ -20,10 +25,49 @@ class _SettingScreen extends State<SettingScreen> {
 
   late UserProvider _userProvider;
 
-  late List<bool> isSelectedMechanical = [false, true];
-  late List<bool> isSelectedSmall = [false, true];
-  late List<bool> isSelectedDistance = [false, false, false, true];
-  late List<bool> isSelectedPrice = [false, false, false, true];
+  late List<bool> isSelectedMechanical = [false, false];
+  late List<bool> isSelectedSmall = [false, false];
+  late List<bool> isSelectedDistance = [false, false, false, false];
+  late List<bool> isSelectedPrice = [false, false, false, false];
+
+  Future<void> init(String token) async {
+    Uri patchUri = Uri.parse("http://10.0.2.2:8080/api/preference/");
+
+    final response = await http.get(patchUri, headers: {
+      HttpHeaders.authorizationHeader: token,
+      'content-type': 'application/json'
+    });
+
+    if (response.statusCode != 200) {
+      throw Exception("[ERROR] Can't get user preference from server");
+    }
+
+    final body = jsonDecode(response.body);
+
+    isSelectedDistance[getIndexOfDistance(body["dist_prefer"])] = true;
+    isSelectedPrice[getIndexOfCost(body["cost_prefer"])] = true;
+
+    if (body["can_mechanical"] == true) {
+      isSelectedMechanical[1] = true;
+    } else {
+      isSelectedMechanical[0] = true;
+    }
+
+    if (body["can_narrow"] == true) {
+      isSelectedSmall[1] = true;
+    } else {
+      isSelectedSmall[0] = true;
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      init(context.read<UserProvider>().token).then((_) => setState(() {}));
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,9 +77,25 @@ class _SettingScreen extends State<SettingScreen> {
 
     _userProvider = Provider.of<UserProvider>(context);
 
-    void _submit() {
-      Navigator.push(
-          context, MaterialPageRoute(builder: (context) => const MyApp()));
+    Future<bool> _submit() async {
+      Uri patchUri = Uri.parse("http://10.0.2.2:8080/api/preference/");
+
+      final body = jsonEncode({
+        "dist_prefer": getDistanceFromSelectedList(isSelectedDistance),
+        "cost_prefer": getCostFromSelectedList(isSelectedPrice),
+        "can_mechanical": (isSelectedMechanical[0] == false),
+        "can_narrow": (isSelectedSmall[0] == false),
+      });
+
+      final response = await http.patch(patchUri, body: body, headers: {
+        HttpHeaders.authorizationHeader: _userProvider.token,
+        'content-type': 'application/json'
+      });
+
+      if (response.statusCode != 200) {
+        return false;
+      }
+      return true;
     }
 
     final marginInputForm = width * 0.09;
@@ -52,11 +112,6 @@ class _SettingScreen extends State<SettingScreen> {
               textAlign: TextAlign.center,
               style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
-            // const Text(
-            //   '선호도를 알려주세요!',
-            //   textAlign: TextAlign.center,
-            //   style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-            // ),
             Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
@@ -78,22 +133,37 @@ class _SettingScreen extends State<SettingScreen> {
                 Container(
                   margin: EdgeInsets.fromLTRB(0, height * 0.03, 0, 0),
                   child: _inputPrefer2(
-                      "거리", "~0.5km", "~1km", "~1.5km", "상관 없어"),
+                      "거리",
+                      distanceToString(distances[0]),
+                      distanceToString(distances[1]),
+                      distanceToString(distances[2]),
+                      distanceToString(distances[3])),
                 ),
                 Container(
                   margin:
                       EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
-                  child:
-                      _inputPrefer2("요금", "무료만", "~500원", "~1000원", "상관 없어"),
+                  child: _inputPrefer2(
+                      "요금",
+                      costToString(costs[0]),
+                      costToString(costs[1]),
+                      costToString(costs[2]),
+                      costToString(costs[3])),
                 ),
               ],
             ),
             ElevatedButton(
               style: ElevatedButton.styleFrom(
                   padding: EdgeInsets.symmetric(vertical: height * 0.015)),
-              onPressed: () => _submit(),
+              onPressed: () async {
+                await _submit().then((isSubmitted) {
+                  if (isSubmitted = true) {
+                    Navigator.push(context,
+                        MaterialPageRoute(builder: (context) => const MyApp()));
+                  }
+                });
+              },
               child: const Text(
-                '확인',
+                '설정 저장하기',
                 style: TextStyle(fontSize: 18),
               ),
             ),
@@ -236,4 +306,3 @@ class _SettingScreen extends State<SettingScreen> {
     );
   }
 }
-

--- a/lib/screen/screen_setting.dart
+++ b/lib/screen/screen_setting.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:asap_client/main.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:asap_client/screen/screen_login.dart';
 
 import '../provider/provider_user.dart';
 

--- a/lib/screen/screen_sign_up.dart
+++ b/lib/screen/screen_sign_up.dart
@@ -144,14 +144,12 @@ class _SignUpScreen extends State<SignUpScreen> {
       }
 
       return true;
-
-      // _submit();
     }
 
     Future<void> alertSignUpFail() async {
       return showDialog<void>(
         context: context,
-        barrierDismissible: false, // user must tap button!
+        barrierDismissible: false,
         builder: (BuildContext context) {
           return AlertDialog(
             title: const Text("회원가입 실패"),
@@ -192,90 +190,88 @@ class _SignUpScreen extends State<SignUpScreen> {
         appBar: AppBar(
           title: const Text('회원가입'),
         ),
-        body: Container(
-          child: ListView(
-            children: <Widget>[
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Container(
-                      margin: EdgeInsets.fromLTRB(
-                          marginInputForm, height * 0.02, marginInputForm, 0),
-                      child: _inputForm("이름", _nameController, '', width)),
-                  Container(
-                      margin: EdgeInsets.fromLTRB(
-                          marginInputForm, 0, marginInputForm, 0),
-                      child: _inputForm(
-                          "이메일", _emailController, _emailErrorMsg, width)),
-                  Container(
-                      margin: EdgeInsets.fromLTRB(
-                          marginInputForm, 0, marginInputForm, 0),
-                      child: _inputForm("비밀번호", _passwordController,
-                          _passwordErrorMsg, width)),
-                  Container(
-                      margin: EdgeInsets.fromLTRB(
-                          marginInputForm, 0, marginInputForm, height * 0.055),
-                      child: _inputForm("비밀번호 확인", _passwordCheckController,
-                          _passwordCheckErrorMsg, width)),
-                ],
-              ),
-              const Text(
-                '선호도를 알려주세요!',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Container(
-                    margin: EdgeInsets.fromLTRB(marginInputForm, height * 0.03,
-                        marginInputForm, height * 0.015),
-                    child: _inputPrefer1("기계식 주차장"),
-                  ),
-                  Container(
+        body: ListView(
+          children: <Widget>[
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Container(
+                    margin: EdgeInsets.fromLTRB(
+                        marginInputForm, height * 0.02, marginInputForm, 0),
+                    child: _inputForm("이름", _nameController, '', width)),
+                Container(
                     margin: EdgeInsets.fromLTRB(
                         marginInputForm, 0, marginInputForm, 0),
-                    child: _inputPrefer1("좁은 주차장"),
-                  )
-                ],
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Container(
-                    margin: EdgeInsets.fromLTRB(0, height * 0.03, 0, 0),
-                    child: _inputPrefer2(
-                        "거리", "~0.5km", "~1km", "~1.5km", "상관 없어"),
-                  ),
-                  Container(
-                    margin:
-                        EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
-                    child:
-                        _inputPrefer2("요금", "무료만", "~500원", "~1000원", "상관 없어"),
-                  ),
-                ],
-              ),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                    padding: EdgeInsets.symmetric(vertical: height * 0.015)),
-                onPressed: () async {
-                  var isValidated = await _checkValidation();
-                  if (isValidated == true) {
-                    var isSubmitted = await _submit();
-                    if (isSubmitted == true) {
-                      await alertSignUpSuccess();
-                    } else {
-                      await alertSignUpFail();
-                    }
-                  }
-                },
-                child: const Text(
-                  '가입하기',
-                  style: TextStyle(fontSize: 18),
+                    child: _inputForm(
+                        "이메일", _emailController, _emailErrorMsg, width)),
+                Container(
+                    margin: EdgeInsets.fromLTRB(
+                        marginInputForm, 0, marginInputForm, 0),
+                    child: _inputForm("비밀번호", _passwordController,
+                        _passwordErrorMsg, width)),
+                Container(
+                    margin: EdgeInsets.fromLTRB(
+                        marginInputForm, 0, marginInputForm, height * 0.055),
+                    child: _inputForm("비밀번호 확인", _passwordCheckController,
+                        _passwordCheckErrorMsg, width)),
+              ],
+            ),
+            const Text(
+              '선호도를 알려주세요!',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Container(
+                  margin: EdgeInsets.fromLTRB(marginInputForm, height * 0.03,
+                      marginInputForm, height * 0.015),
+                  child: _inputPrefer1("기계식 주차장"),
                 ),
+                Container(
+                  margin: EdgeInsets.fromLTRB(
+                      marginInputForm, 0, marginInputForm, 0),
+                  child: _inputPrefer1("좁은 주차장"),
+                )
+              ],
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Container(
+                  margin: EdgeInsets.fromLTRB(0, height * 0.03, 0, 0),
+                  child: _inputPrefer2(
+                      "거리", "~0.5km", "~1km", "~1.5km", "상관 없어"),
+                ),
+                Container(
+                  margin:
+                      EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
+                  child:
+                      _inputPrefer2("요금", "무료만", "~500원", "~1000원", "상관 없어"),
+                ),
+              ],
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                  padding: EdgeInsets.symmetric(vertical: height * 0.015)),
+              onPressed: () async {
+                var isValidated = await _checkValidation();
+                if (isValidated == true) {
+                  var isSubmitted = await _submit();
+                  if (isSubmitted == true) {
+                    await alertSignUpSuccess();
+                  } else {
+                    await alertSignUpFail();
+                  }
+                }
+              },
+              child: const Text(
+                '가입하기',
+                style: TextStyle(fontSize: 18),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screen/screen_sign_up.dart
+++ b/lib/screen/screen_sign_up.dart
@@ -14,7 +14,7 @@ class SignUpScreen extends StatefulWidget {
   @override
   State<StatefulWidget> createState() {
     return _SignUpScreen();
-  }가
+  }
 }
 
 class _SignUpScreen extends State<SignUpScreen> {

--- a/lib/screen/screen_sign_up.dart
+++ b/lib/screen/screen_sign_up.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:ui';
 
-import 'package:asap_client/main.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:asap_client/screen/screen_login.dart';

--- a/lib/screen/screen_sign_up.dart
+++ b/lib/screen/screen_sign_up.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:ui';
 
@@ -6,12 +7,14 @@ import 'package:provider/provider.dart';
 import 'package:asap_client/screen/screen_login.dart';
 
 import '../provider/provider_user.dart';
+
 import 'package:http/http.dart' as http;
 
 class SignUpScreen extends StatefulWidget {
+  @override
   State<StatefulWidget> createState() {
     return _SignUpScreen();
-  }
+  }가
 }
 
 class _SignUpScreen extends State<SignUpScreen> {
@@ -35,7 +38,6 @@ class _SignUpScreen extends State<SignUpScreen> {
   late List<bool> isSelectedDistance = [false, false, false, true];
   late List<bool> isSelectedPrice = [false, false, false, true];
 
-
   @override
   Widget build(BuildContext context) {
     screenSize = MediaQuery.of(context).size;
@@ -44,32 +46,77 @@ class _SignUpScreen extends State<SignUpScreen> {
 
     _userProvider = Provider.of<UserProvider>(context);
 
-    Future<void> _submit() async {
+    void saveInLocal() {
       _userProvider.email = _emailController.text;
       _userProvider.name = _nameController.text;
       _userProvider.password = _passwordController.text;
+      _userProvider.distPrefer = getDistPreferInt();
+      _userProvider.costPrefer = getCostPreferInt();
+      _userProvider.canMechanical = (isSelectedMechanical[0] == false);
+      _userProvider.canNarrow = (isSelectedSmall[0] == false);
+    }
 
-      var url = Uri.parse('http://staya.koreacentral.cloudapp.azure.com:8080/api/auth/signup');
-      Map data = {
+    void savePreferenceInServer(String userId) async {
+      Uri preferenceUri =
+          Uri.parse("http://10.0.2.2:8080/api/auth/signup/preference/");
+
+      final body = jsonEncode({
+        "user_id": userId,
+        "dist_prefer": _userProvider.distPrefer,
+        "cost_prefer": _userProvider.costPrefer,
+        "can_mechanical": _userProvider.canMechanical,
+        "can_narrow": _userProvider.canNarrow,
+      });
+
+      final response = await http
+          .post(preferenceUri,
+              headers: {'content-type': 'application/json'}, body: body)
+          .catchError((onError) => onError);
+
+      if (response.statusCode != 200) {
+        throw Exception("[ERROR] can't create preference of user $userId");
+      }
+    }
+
+    Future<String> saveUserInServer() async {
+      late String userId;
+      Uri userUri = Uri.parse("http://10.0.2.2:8080/api/auth/signup/user/");
+
+      final body = jsonEncode({
         "username": _userProvider.name,
         "email": _userProvider.email,
         "password": _userProvider.password
-      };
-      var response = await http.post(url, body: json.encode(data), headers: {
-        'Content-Type': 'application/json'
       });
-      print('Response status: ${response.statusCode}');
-      print('Response body: ${response.body}');
 
-      Navigator.push(
-          context, MaterialPageRoute(builder: (context) => LoginPage()));
-      ////////to popup
+      final response = await http
+          .post(userUri,
+              headers: {'content-type': 'application/json'}, body: body)
+          .catchError((onError) => onError);
+
+      if (response.statusCode == 200 && response.body != "[ERROR] same user") {
+        userId = response.body;
+        savePreferenceInServer(response.body);
+        return userId;
+      } else {
+        return "[ERROR] same user";
+      }
     }
 
-    void _checkValidation() async {
+    Future<bool> _submit() async {
+      saveInLocal();
+      final result = await saveUserInServer();
+
+      if (result == "[ERROR] same user") {
+        return false;
+      } else {
+        return true;
+      }
+    }
+
+    Future<bool> _checkValidation() async {
       String emailPattern =
           r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$';
-      RegExp regExp = new RegExp(emailPattern);
+      RegExp regExp = RegExp(emailPattern);
 
       setState(() {
         _emailErrorMsg = "";
@@ -81,25 +128,64 @@ class _SignUpScreen extends State<SignUpScreen> {
         setState(() {
           _emailErrorMsg = "이메일 형식이 올바르지 않습니다";
         });
-        return;
+        return false;
       }
       if (_passwordController.text.length < 8) {
         setState(() {
           _passwordErrorMsg = "비밀번호는 8자리 이상이어야 합니다";
         });
-        return;
+        return false;
       }
       if (_passwordController.text != _passwordCheckController.text) {
         setState(() {
           _passwordCheckErrorMsg = "비밀번호가 일치하지 않습니다";
         });
-        return;
+        return false;
       }
 
-      _submit();
+      return true;
+
+      // _submit();
     }
 
-    final _marginInputForm = width * 0.08;
+    Future<void> alertSignUpFail() async {
+      return showDialog<void>(
+        context: context,
+        barrierDismissible: false, // user must tap button!
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text("회원가입 실패"),
+            content: const Text("해당 이메일로 가입한 유저가 이미 존재합니다"),
+            actions: <Widget>[
+              ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text("확인"))
+            ],
+          );
+        },
+      );
+    }
+
+    Future<void> alertSignUpSuccess() async {
+      return showDialog<void>(
+        context: context,
+        barrierDismissible: false, // user must tap button!
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text("회원가입 성공"),
+            content: const Text("회원가입을 축하드립니다"),
+            actions: <Widget>[
+              ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                      MaterialPageRoute(builder: (context) => LoginPage())),
+                  child: const Text("확인"))
+            ],
+          );
+        },
+      );
+    }
+
+    final marginInputForm = width * 0.08;
 
     return SafeArea(
       child: Scaffold(
@@ -113,18 +199,22 @@ class _SignUpScreen extends State<SignUpScreen> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, height * 0.02, _marginInputForm, 0),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, height * 0.02, marginInputForm, 0),
                       child: _inputForm("이름", _nameController, '', width)),
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, 0),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, 0, marginInputForm, 0),
                       child: _inputForm(
                           "이메일", _emailController, _emailErrorMsg, width)),
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, 0),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, 0, marginInputForm, 0),
                       child: _inputForm("비밀번호", _passwordController,
                           _passwordErrorMsg, width)),
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, height * 0.055),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, 0, marginInputForm, height * 0.055),
                       child: _inputForm("비밀번호 확인", _passwordCheckController,
                           _passwordCheckErrorMsg, width)),
                 ],
@@ -138,11 +228,13 @@ class _SignUpScreen extends State<SignUpScreen> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
                   Container(
-                    margin: EdgeInsets.fromLTRB(_marginInputForm, height * 0.03, _marginInputForm, height * 0.015),
+                    margin: EdgeInsets.fromLTRB(marginInputForm, height * 0.03,
+                        marginInputForm, height * 0.015),
                     child: _inputPrefer1("기계식 주차장"),
                   ),
                   Container(
-                    margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, 0),
+                    margin: EdgeInsets.fromLTRB(
+                        marginInputForm, 0, marginInputForm, 0),
                     child: _inputPrefer1("좁은 주차장"),
                   )
                 ],
@@ -156,7 +248,8 @@ class _SignUpScreen extends State<SignUpScreen> {
                         "거리", "~0.5km", "~1km", "~1.5km", "상관 없어"),
                   ),
                   Container(
-                    margin: EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
+                    margin:
+                        EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
                     child:
                         _inputPrefer2("요금", "무료만", "~500원", "~1000원", "상관 없어"),
                   ),
@@ -165,12 +258,21 @@ class _SignUpScreen extends State<SignUpScreen> {
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                     padding: EdgeInsets.symmetric(vertical: height * 0.015)),
-                onPressed: () => _checkValidation(),
+                onPressed: () async {
+                  var isValidated = await _checkValidation();
+                  if (isValidated == true) {
+                    var isSubmitted = await _submit();
+                    if (isSubmitted == true) {
+                      await alertSignUpSuccess();
+                    } else {
+                      await alertSignUpFail();
+                    }
+                  }
+                },
                 child: const Text(
                   '가입하기',
                   style: TextStyle(fontSize: 18),
                 ),
-
               ),
             ],
           ),
@@ -276,7 +378,8 @@ class _SignUpScreen extends State<SignUpScreen> {
               );
             },
             borderRadius: BorderRadius.circular(9),
-            constraints: BoxConstraints(minHeight: height * 0.045, minWidth: width * 0.2),
+            constraints: BoxConstraints(
+                minHeight: height * 0.045, minWidth: width * 0.2),
             children: [
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: height * 0.015),
@@ -309,6 +412,30 @@ class _SignUpScreen extends State<SignUpScreen> {
             ]),
       ],
     );
+  }
+
+  double getDistPreferInt() {
+    if (isSelectedDistance[0]) {
+      return 0.5;
+    } else if (isSelectedDistance[1]) {
+      return 1.0;
+    } else if (isSelectedDistance[2]) {
+      return 1.5;
+    } else {
+      return 0.0;
+    }
+  }
+
+  double getCostPreferInt() {
+    if (isSelectedPrice[0]) {
+      return 500;
+    } else if (isSelectedPrice[1]) {
+      return 1000;
+    } else if (isSelectedPrice[2]) {
+      return 1500;
+    } else {
+      return 0.0;
+    }
   }
 }
 
@@ -354,8 +481,8 @@ Widget _inputForm(String type, TextEditingController textEditingController,
         type,
         textAlign: TextAlign.center,
         style: const TextStyle(
-            fontSize: 18,
-            fontFeatures: [FontFeature.tabularFigures()],
+          fontSize: 18,
+          fontFeatures: [FontFeature.tabularFigures()],
         ),
       ),
       Padding(padding: EdgeInsets.only(left: width * 0.06)),
@@ -363,4 +490,3 @@ Widget _inputForm(String type, TextEditingController textEditingController,
     ],
   );
 }
-

--- a/lib/screen/screen_sign_up.dart
+++ b/lib/screen/screen_sign_up.dart
@@ -1,18 +1,20 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:ui';
 
-import 'package:asap_client/main.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:asap_client/screen/screen_login.dart';
 
 import '../provider/provider_user.dart';
+
 import 'package:http/http.dart' as http;
 
 class SignUpScreen extends StatefulWidget {
+  @override
   State<StatefulWidget> createState() {
     return _SignUpScreen();
-  }
+  }가
 }
 
 class _SignUpScreen extends State<SignUpScreen> {
@@ -36,7 +38,6 @@ class _SignUpScreen extends State<SignUpScreen> {
   late List<bool> isSelectedDistance = [false, false, false, true];
   late List<bool> isSelectedPrice = [false, false, false, true];
 
-
   @override
   Widget build(BuildContext context) {
     screenSize = MediaQuery.of(context).size;
@@ -45,32 +46,77 @@ class _SignUpScreen extends State<SignUpScreen> {
 
     _userProvider = Provider.of<UserProvider>(context);
 
-    Future<void> _submit() async {
+    void saveInLocal() {
       _userProvider.email = _emailController.text;
       _userProvider.name = _nameController.text;
       _userProvider.password = _passwordController.text;
+      _userProvider.distPrefer = getDistPreferInt();
+      _userProvider.costPrefer = getCostPreferInt();
+      _userProvider.canMechanical = (isSelectedMechanical[0] == false);
+      _userProvider.canNarrow = (isSelectedSmall[0] == false);
+    }
 
-      var url = Uri.parse('http://staya.koreacentral.cloudapp.azure.com:8080/api/auth/signup');
-      Map data = {
+    void savePreferenceInServer(String userId) async {
+      Uri preferenceUri =
+          Uri.parse("http://10.0.2.2:8080/api/auth/signup/preference/");
+
+      final body = jsonEncode({
+        "user_id": userId,
+        "dist_prefer": _userProvider.distPrefer,
+        "cost_prefer": _userProvider.costPrefer,
+        "can_mechanical": _userProvider.canMechanical,
+        "can_narrow": _userProvider.canNarrow,
+      });
+
+      final response = await http
+          .post(preferenceUri,
+              headers: {'content-type': 'application/json'}, body: body)
+          .catchError((onError) => onError);
+
+      if (response.statusCode != 200) {
+        throw Exception("[ERROR] can't create preference of user $userId");
+      }
+    }
+
+    Future<String> saveUserInServer() async {
+      late String userId;
+      Uri userUri = Uri.parse("http://10.0.2.2:8080/api/auth/signup/user/");
+
+      final body = jsonEncode({
         "username": _userProvider.name,
         "email": _userProvider.email,
         "password": _userProvider.password
-      };
-      var response = await http.post(url, body: json.encode(data), headers: {
-        'Content-Type': 'application/json'
       });
-      print('Response status: ${response.statusCode}');
-      print('Response body: ${response.body}');
 
-      Navigator.push(
-          context, MaterialPageRoute(builder: (context) => LoginPage()));
-      ////////to popup
+      final response = await http
+          .post(userUri,
+              headers: {'content-type': 'application/json'}, body: body)
+          .catchError((onError) => onError);
+
+      if (response.statusCode == 200 && response.body != "[ERROR] same user") {
+        userId = response.body;
+        savePreferenceInServer(response.body);
+        return userId;
+      } else {
+        return "[ERROR] same user";
+      }
     }
 
-    void _checkValidation() async {
+    Future<bool> _submit() async {
+      saveInLocal();
+      final result = await saveUserInServer();
+
+      if (result == "[ERROR] same user") {
+        return false;
+      } else {
+        return true;
+      }
+    }
+
+    Future<bool> _checkValidation() async {
       String emailPattern =
           r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$';
-      RegExp regExp = new RegExp(emailPattern);
+      RegExp regExp = RegExp(emailPattern);
 
       setState(() {
         _emailErrorMsg = "";
@@ -82,25 +128,64 @@ class _SignUpScreen extends State<SignUpScreen> {
         setState(() {
           _emailErrorMsg = "이메일 형식이 올바르지 않습니다";
         });
-        return;
+        return false;
       }
       if (_passwordController.text.length < 8) {
         setState(() {
           _passwordErrorMsg = "비밀번호는 8자리 이상이어야 합니다";
         });
-        return;
+        return false;
       }
       if (_passwordController.text != _passwordCheckController.text) {
         setState(() {
           _passwordCheckErrorMsg = "비밀번호가 일치하지 않습니다";
         });
-        return;
+        return false;
       }
 
-      _submit();
+      return true;
+
+      // _submit();
     }
 
-    final _marginInputForm = width * 0.08;
+    Future<void> alertSignUpFail() async {
+      return showDialog<void>(
+        context: context,
+        barrierDismissible: false, // user must tap button!
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text("회원가입 실패"),
+            content: const Text("해당 이메일로 가입한 유저가 이미 존재합니다"),
+            actions: <Widget>[
+              ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text("확인"))
+            ],
+          );
+        },
+      );
+    }
+
+    Future<void> alertSignUpSuccess() async {
+      return showDialog<void>(
+        context: context,
+        barrierDismissible: false, // user must tap button!
+        builder: (BuildContext context) {
+          return AlertDialog(
+            title: const Text("회원가입 성공"),
+            content: const Text("회원가입을 축하드립니다"),
+            actions: <Widget>[
+              ElevatedButton(
+                  onPressed: () => Navigator.push(context,
+                      MaterialPageRoute(builder: (context) => LoginPage())),
+                  child: const Text("확인"))
+            ],
+          );
+        },
+      );
+    }
+
+    final marginInputForm = width * 0.08;
 
     return SafeArea(
       child: Scaffold(
@@ -114,18 +199,22 @@ class _SignUpScreen extends State<SignUpScreen> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, height * 0.02, _marginInputForm, 0),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, height * 0.02, marginInputForm, 0),
                       child: _inputForm("이름", _nameController, '', width)),
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, 0),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, 0, marginInputForm, 0),
                       child: _inputForm(
                           "이메일", _emailController, _emailErrorMsg, width)),
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, 0),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, 0, marginInputForm, 0),
                       child: _inputForm("비밀번호", _passwordController,
                           _passwordErrorMsg, width)),
                   Container(
-                      margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, height * 0.055),
+                      margin: EdgeInsets.fromLTRB(
+                          marginInputForm, 0, marginInputForm, height * 0.055),
                       child: _inputForm("비밀번호 확인", _passwordCheckController,
                           _passwordCheckErrorMsg, width)),
                 ],
@@ -139,11 +228,13 @@ class _SignUpScreen extends State<SignUpScreen> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
                   Container(
-                    margin: EdgeInsets.fromLTRB(_marginInputForm, height * 0.03, _marginInputForm, height * 0.015),
+                    margin: EdgeInsets.fromLTRB(marginInputForm, height * 0.03,
+                        marginInputForm, height * 0.015),
                     child: _inputPrefer1("기계식 주차장"),
                   ),
                   Container(
-                    margin: EdgeInsets.fromLTRB(_marginInputForm, 0, _marginInputForm, 0),
+                    margin: EdgeInsets.fromLTRB(
+                        marginInputForm, 0, marginInputForm, 0),
                     child: _inputPrefer1("좁은 주차장"),
                   )
                 ],
@@ -157,7 +248,8 @@ class _SignUpScreen extends State<SignUpScreen> {
                         "거리", "~0.5km", "~1km", "~1.5km", "상관 없어"),
                   ),
                   Container(
-                    margin: EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
+                    margin:
+                        EdgeInsets.fromLTRB(0, height * 0.02, 0, height * 0.05),
                     child:
                         _inputPrefer2("요금", "무료만", "~500원", "~1000원", "상관 없어"),
                   ),
@@ -166,12 +258,21 @@ class _SignUpScreen extends State<SignUpScreen> {
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                     padding: EdgeInsets.symmetric(vertical: height * 0.015)),
-                onPressed: () => _checkValidation(),
+                onPressed: () async {
+                  var isValidated = await _checkValidation();
+                  if (isValidated == true) {
+                    var isSubmitted = await _submit();
+                    if (isSubmitted == true) {
+                      await alertSignUpSuccess();
+                    } else {
+                      await alertSignUpFail();
+                    }
+                  }
+                },
                 child: const Text(
                   '가입하기',
                   style: TextStyle(fontSize: 18),
                 ),
-
               ),
             ],
           ),
@@ -277,7 +378,8 @@ class _SignUpScreen extends State<SignUpScreen> {
               );
             },
             borderRadius: BorderRadius.circular(9),
-            constraints: BoxConstraints(minHeight: height * 0.045, minWidth: width * 0.2),
+            constraints: BoxConstraints(
+                minHeight: height * 0.045, minWidth: width * 0.2),
             children: [
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: height * 0.015),
@@ -310,6 +412,30 @@ class _SignUpScreen extends State<SignUpScreen> {
             ]),
       ],
     );
+  }
+
+  double getDistPreferInt() {
+    if (isSelectedDistance[0]) {
+      return 0.5;
+    } else if (isSelectedDistance[1]) {
+      return 1.0;
+    } else if (isSelectedDistance[2]) {
+      return 1.5;
+    } else {
+      return 0.0;
+    }
+  }
+
+  double getCostPreferInt() {
+    if (isSelectedPrice[0]) {
+      return 500;
+    } else if (isSelectedPrice[1]) {
+      return 1000;
+    } else if (isSelectedPrice[2]) {
+      return 1500;
+    } else {
+      return 0.0;
+    }
   }
 }
 
@@ -355,8 +481,8 @@ Widget _inputForm(String type, TextEditingController textEditingController,
         type,
         textAlign: TextAlign.center,
         style: const TextStyle(
-            fontSize: 18,
-            fontFeatures: [FontFeature.tabularFigures()],
+          fontSize: 18,
+          fontFeatures: [FontFeature.tabularFigures()],
         ),
       ),
       Padding(padding: EdgeInsets.only(left: width * 0.06)),
@@ -364,4 +490,3 @@ Widget _inputForm(String type, TextEditingController textEditingController,
     ],
   );
 }
-

--- a/lib/screen/screen_voice1.dart
+++ b/lib/screen/screen_voice1.dart
@@ -1,8 +1,12 @@
 import 'dart:async';
+import 'dart:collection';
 import 'package:asap_client/screen/screen_voice2.dart';
 import 'package:flutter/material.dart';
-import 'package:asap_client/screen/screen_selection.dart';
 
+import 'package:avatar_glow/avatar_glow.dart';
+import 'package:highlight_text/highlight_text.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+import 'package:duration_button/duration_button.dart';
 
 class Voice1 extends StatefulWidget {
   @override
@@ -13,17 +17,188 @@ class _Voice1 extends State<Voice1> {
   @override
   void initState(){
     super.initState();
-    Timer(Duration(seconds: 3), (){
-      Navigator.push(context, MaterialPageRoute(builder: (context) => Voice2()));
-    });
+    //Timer(Duration(seconds: 10), (){
+
+    //  Navigator.push(context, MaterialPageRoute(builder: (context) => Voice2(title: _text)));
+
+    //});
   }
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Text('어디로 안내할까요?',style:TextStyle(fontSize: 25)),
-        ),
+      title: 'Flutter Voice',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        primarySwatch: Colors.indigo,
+        visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
+      home: SpeechScreen(),
     );
   }
 }
+
+class ReturnValue{
+  String? result = '';
+  ReturnValue({this.result});
+}
+// 데이터 전달에 사용할 클래스
+class Arguments {
+  String arg;   // 전달에 사용할 데이터
+  ReturnValue? returnValue;
+  Arguments({this.arg: '', this.returnValue});
+}
+
+
+class SpeechScreen extends StatefulWidget{
+  @override
+  _SpeechScreenState createState() => _SpeechScreenState();
+}
+
+class _SpeechScreenState extends State<SpeechScreen>{
+
+  final Map<String, HighlightedWord> _highlights = {
+    'flutter': HighlightedWord(
+      onTap: () => print('flutter'),
+      textStyle: const TextStyle(
+        color: Colors.blue,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'voice': HighlightedWord(
+      onTap: () => print('voice'),
+      textStyle: const TextStyle(
+        color: Colors.green,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'subscribe': HighlightedWord(
+      onTap: () => print('subscribe'),
+      textStyle: const TextStyle(
+        color: Colors.red,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'like': HighlightedWord(
+      onTap: () => print('like'),
+      textStyle: const TextStyle(
+        color: Colors.blueAccent,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'comment': HighlightedWord(
+      onTap: () => print('comment'),
+      textStyle: const TextStyle(
+        color: Colors.green,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+  };
+
+  stt.SpeechToText _speech = stt.SpeechToText();
+  bool _isListening = false;
+  String _text = '목적지를 말하세요';
+  double _confidence = 1.0;
+
+  late var locales =  _speech.locales();
+
+  @override
+  void initState(){
+    super.initState();
+    _speech = stt.SpeechToText();
+    locales = _speech.locales();
+  }
+
+  @override
+  Widget build(BuildContext context){
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(''),
+
+      ),
+
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: AvatarGlow(
+        animate: _isListening,
+        glowColor: Theme.of(context).primaryColor,
+        endRadius: 75.0,
+        duration: const Duration(milliseconds: 800),
+        repeatPauseDuration: const Duration(milliseconds: 800),
+        repeat: true,
+
+        //child: FloatingActionButton(
+        //  onPressed: _listen ,
+        //  child: Icon(_isListening ? Icons.mic : Icons.mic_none),
+        //),
+        child: DurationButton(
+          duration: const Duration(seconds: 1),
+          onPressed: () {},
+          backgroundColor: Colors.blueAccent,
+          splashFactory: NoSplash.splashFactory,
+          onComplete: _listen,
+          child: Icon(Icons.mic)
+        ),
+
+      ),
+
+      body: SingleChildScrollView(
+        reverse: true,
+
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 0.0),
+          child: TextHighlight(
+              text: _text,
+              words : LinkedHashMap<String, HighlightedWord>(),
+              textStyle: const TextStyle(
+                fontSize: 32.0,
+                color: Colors.black,
+                fontWeight: FontWeight.w400,
+              ),
+          ),
+        ),
+
+      ),
+
+    );
+
+  }
+
+  void _listen() async{
+
+    if (!_isListening){
+      bool available = await _speech.initialize(
+        onStatus: (val) => print('onStatus33: $val'),
+        onError: (val) => print('onError: $val'),
+      );
+      if (available){
+        setState(()=> _isListening = true);
+        _speech.listen(
+          onResult: (val) => setState(() {
+            _text = val.recognizedWords;
+            if (val.hasConfidenceRating && val.confidence > 0){
+              _confidence = val.confidence;
+            }
+          }),
+          localeId: 'ko'
+        );
+      }
+      Timer(Duration(seconds: 5), (){
+
+        setState(() => _isListening = false);
+        _speech.stop();
+        print(_text);
+        Timer(Duration(seconds: 5), (){
+
+          Navigator.push(context, MaterialPageRoute(builder: (context) => Voice2(_text)));
+
+        });
+      });
+    }else {
+      print('aaaaaa');
+      setState(() => _isListening = false);
+      _speech.stop();
+    }
+  }
+
+
+}
+

--- a/lib/screen/screen_voice1.dart
+++ b/lib/screen/screen_voice1.dart
@@ -18,9 +18,7 @@ class _Voice1 extends State<Voice1> {
   void initState(){
     super.initState();
     //Timer(Duration(seconds: 10), (){
-
     //  Navigator.push(context, MaterialPageRoute(builder: (context) => Voice2(title: _text)));
-
     //});
   }
   Widget build(BuildContext context) {
@@ -44,7 +42,7 @@ class ReturnValue{
 class Arguments {
   String arg;   // 전달에 사용할 데이터
   ReturnValue? returnValue;
-  Arguments({this.arg: '', this.returnValue});
+  Arguments({this.arg = '', this.returnValue});
 }
 
 
@@ -113,7 +111,6 @@ class _SpeechScreenState extends State<SpeechScreen>{
     return Scaffold(
       appBar: AppBar(
         title: Text(''),
-
       ),
 
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
@@ -137,7 +134,6 @@ class _SpeechScreenState extends State<SpeechScreen>{
           onComplete: _listen,
           child: Icon(Icons.mic)
         ),
-
       ),
 
       body: SingleChildScrollView(
@@ -155,15 +151,12 @@ class _SpeechScreenState extends State<SpeechScreen>{
               ),
           ),
         ),
-
       ),
-
     );
 
   }
 
   void _listen() async{
-
     if (!_isListening){
       bool available = await _speech.initialize(
         onStatus: (val) => print('onStatus33: $val'),
@@ -181,15 +174,12 @@ class _SpeechScreenState extends State<SpeechScreen>{
           localeId: 'ko'
         );
       }
-      Timer(Duration(seconds: 5), (){
-
+      Timer(const Duration(seconds: 5), (){
         setState(() => _isListening = false);
         _speech.stop();
         print(_text);
-        Timer(Duration(seconds: 5), (){
-
+        Timer(const Duration(seconds: 3), (){
           Navigator.push(context, MaterialPageRoute(builder: (context) => Voice2(_text)));
-
         });
       });
     }else {

--- a/lib/screen/screen_voice2.dart
+++ b/lib/screen/screen_voice2.dart
@@ -29,7 +29,6 @@ class _Voice2 extends State<Voice2> {
     super.initState();
     //int parking = 0;
     //Timer(Duration(seconds: 10), (){
-
     //  Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(parking)));
     //});
   }
@@ -103,34 +102,22 @@ class _SpeechScreenState extends State<SpeechScreen>{
 
 
   Future<void> _submit() async {
-
-    print(id);
     String new_name = id;
     new_name = id.replaceAll(' ','');
     print('AAA');
     print(id);
     print(new_name);
-    var url = Uri.parse('http://localhost:8080/api/parking/latlng?searching='+new_name);
-    print(url);
-    Map data = {
-     'name': _text
-    };
+    var url = Uri.parse('http://staya.koreacentral.cloudapp.azure.com:8080/api/parking/latlng?searching='+new_name);
+    // print(url);
     var response = await http.get(url);
-
-    //print('Response status: ${response.statusCode}');
-    //print('Response body: ${response.body}');
-
-
-
+    print("0:"+response.body);
+    List<dynamic> latlng = jsonDecode(response.body);
     if(parking == 1){
-      Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(1,response.body[0],response.body[1])));
-
+      Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(1, latlng[0].toString(), latlng[1].toString())));
     }
     else{
-      Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(0,response.body[0],response.body[1])));
+      Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(0, latlng[0].toString(), latlng[1].toString())));
     }
-
-    ////////to popup
   }
 
   late var locales =  _speech2.locales();
@@ -217,19 +204,18 @@ class _SpeechScreenState extends State<SpeechScreen>{
         );
       }
       Timer(Duration(seconds: 5), (){
-
         setState(() => _isListening = false);
         _speech2.stop();
         print(_text);
         print(id);
-        //if (_text.contains('예') || _text.contains('네')){
-
-        //  Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(1)));
-       // }
-        //else{
-        //  Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(0)));
-        //}
+        if (_text.contains('예') || _text.contains('네')){
+          parking = 1;
+        }
+        else{
+          parking = 0;
+        }
         _submit();
+
       });
     }else {
       print('aaaaaa');

--- a/lib/screen/screen_voice2.dart
+++ b/lib/screen/screen_voice2.dart
@@ -1,76 +1,243 @@
 import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:asap_client/screen/screen_selection.dart';
-
-
+import 'package:avatar_glow/avatar_glow.dart';
+import 'package:highlight_text/highlight_text.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt2;
+import 'package:duration_button/duration_button.dart';
+import 'package:http/http.dart' as http;
 
 
 class Voice2 extends StatefulWidget {
+  String id='';
+  Voice2(this.id);
+
   @override
-  _Voice2 createState() => _Voice2();
+  _Voice2 createState() => _Voice2(this.id);
 }
 
 class _Voice2 extends State<Voice2> {
-  late Size screenSize;
-  late double width;
-  late double height;
-  int parking = -1;
+  String id='';
+  _Voice2(this.id);
+
+
   @override
   void initState(){
     super.initState();
-    /*Timer(Duration(seconds: 3), (){
-      Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen()));
-    });*/
+    //int parking = 0;
+    //Timer(Duration(seconds: 10), (){
+
+    //  Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(parking)));
+    //});
   }
   Widget build(BuildContext context) {
-
-    screenSize = MediaQuery.of(context).size;
-    width = screenSize.width;
-    height = screenSize.height;
-
     return MaterialApp(
-      home: Scaffold(
-        body: Center(
-          child: Column(
-            children: <Widget>[
-              Padding(
-                padding: EdgeInsets.all(height * 0.2),
-              ),
-              Text('주차가 필요하신가요?',style:TextStyle(fontSize: 25)),
-              Padding(
-                padding: EdgeInsets.all(height * 0.01),
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  ElevatedButton(
-
-                    onPressed: () => {
-                        parking = 1,
-                        Navigator.push(context,
-                            MaterialPageRoute(builder: (context) => SelectScreen(parking))),
-                      },
-                    child: Text('네'),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.all(width * 0.01),
-                  ),
-                  ElevatedButton(
-
-                    onPressed: () => {
-                        parking = 0,
-                        Navigator.push(context,
-                        MaterialPageRoute(builder: (context) => SelectScreen(parking))),
-                        },
-                        child: Text('아니오'),
-                  ),
-                ]
-              )
-            ],
-          ),
-
-        ),
+      title: 'Flutter Voice',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        primarySwatch: Colors.indigo,
+        visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
+      home: SpeechScreen(id),
     );
   }
 }
+
+class SpeechScreen extends StatefulWidget{
+  String id='';
+  SpeechScreen(this.id);
+  @override
+  _SpeechScreenState createState() => _SpeechScreenState(id);
+}
+
+class _SpeechScreenState extends State<SpeechScreen>{
+  String id='';
+  _SpeechScreenState(this.id);
+
+  final Map<String, HighlightedWord> _highlights = {
+    'flutter': HighlightedWord(
+      onTap: () => print('flutter'),
+      textStyle: const TextStyle(
+        color: Colors.blue,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'voice': HighlightedWord(
+      onTap: () => print('voice'),
+      textStyle: const TextStyle(
+        color: Colors.green,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'subscribe': HighlightedWord(
+      onTap: () => print('subscribe'),
+      textStyle: const TextStyle(
+        color: Colors.red,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'like': HighlightedWord(
+      onTap: () => print('like'),
+      textStyle: const TextStyle(
+        color: Colors.blueAccent,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+    'comment': HighlightedWord(
+      onTap: () => print('comment'),
+      textStyle: const TextStyle(
+        color: Colors.green,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+  };
+
+  stt2.SpeechToText _speech2 = stt2.SpeechToText();
+  bool _isListening = false;
+  String _text = '주차를 하시겠습니까?';
+  double _confidence = 1.0;
+  int parking = -1;
+
+
+  Future<void> _submit() async {
+
+    print(id);
+    String new_name = id;
+    new_name = id.replaceAll(' ','');
+    print('AAA');
+    print(id);
+    print(new_name);
+    var url = Uri.parse('http://localhost:8080/api/parking/latlng?searching='+new_name);
+    print(url);
+    Map data = {
+     'name': _text
+    };
+    var response = await http.get(url);
+
+    //print('Response status: ${response.statusCode}');
+    //print('Response body: ${response.body}');
+
+
+
+    if(parking == 1){
+      Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(1,response.body[0],response.body[1])));
+
+    }
+    else{
+      Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(0,response.body[0],response.body[1])));
+    }
+
+    ////////to popup
+  }
+
+  late var locales =  _speech2.locales();
+
+  @override
+  void initState(){
+    super.initState();
+    _speech2 = stt2.SpeechToText();
+    locales = _speech2.locales();
+  }
+
+  @override
+  Widget build(BuildContext context){
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(''),
+
+      ),
+
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: AvatarGlow(
+        animate: _isListening,
+        glowColor: Theme.of(context).primaryColor,
+        endRadius: 75.0,
+        duration: const Duration(milliseconds: 2000),
+        repeatPauseDuration: const Duration(milliseconds: 100),
+        repeat: true,
+
+        //child: FloatingActionButton(
+        //  onPressed: _listen ,
+        //  child: Icon(_isListening ? Icons.mic : Icons.mic_none),
+        //),
+        child: DurationButton(
+          duration: const Duration(seconds: 1),
+          onPressed: () {},
+          backgroundColor: Colors.blueAccent,
+          splashFactory: NoSplash.splashFactory,
+          onComplete: _listen2,
+          child: Icon(Icons.mic)
+          //child: const Text("주차장 유무"),
+        ),
+      ),
+
+      body: SingleChildScrollView(
+        reverse: true,
+
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(0.0, 0.0, 0.0, 0.0),
+          child: TextHighlight(
+            text: _text,
+            words : LinkedHashMap<String, HighlightedWord>(),
+            textStyle: const TextStyle(
+              fontSize: 32.0,
+              color: Colors.black,
+              fontWeight: FontWeight.w400,
+            ),
+
+          ),
+        ),
+
+      ),
+    );
+  }
+
+  void _listen2() async{
+
+    if (!_isListening){
+      bool available = await _speech2.initialize(
+
+        onStatus: (val) => print('onStatus44: $val'),
+        onError: (val) => print('onError: $val'),
+      );
+      if (available){
+        setState(()=> _isListening = true);
+        _speech2.listen(
+            onResult: (val) => setState(() {
+              _text= val.recognizedWords;
+              if (val.hasConfidenceRating && val.confidence > 0){
+                _confidence = val.confidence;
+              }
+            }),
+            localeId: 'ko'
+        );
+      }
+      Timer(Duration(seconds: 5), (){
+
+        setState(() => _isListening = false);
+        _speech2.stop();
+        print(_text);
+        print(id);
+        //if (_text.contains('예') || _text.contains('네')){
+
+        //  Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(1)));
+       // }
+        //else{
+        //  Navigator.push(context, MaterialPageRoute(builder: (context) => SelectScreen(0)));
+        //}
+        _submit();
+      });
+    }else {
+      print('aaaaaa');
+      setState(() => _isListening = false);
+      _speech2.stop();
+    }
+  }
+
+
+}
+

--- a/lib/screen/screen_welcome.dart
+++ b/lib/screen/screen_welcome.dart
@@ -2,9 +2,6 @@ import 'dart:async';
 
 import 'package:asap_client/screen/screen_voice1.dart';
 import 'package:flutter/material.dart';
-import 'package:asap_client/screen/screen_selection.dart';
-
-
 
 
 class Welcome extends StatefulWidget {

--- a/lib/util/util_cost.dart
+++ b/lib/util/util_cost.dart
@@ -1,6 +1,6 @@
-const List<double> cost = [0.0, 500.0, 1000.0, -1.0];
+const List<int> costs = [0, 500, 1000, -1];
 
-String costToString(double cost) {
+String costToString(int cost) {
   if (cost == 0.0) {
     return "무료만";
   } else if (cost == -1.0) {
@@ -8,4 +8,17 @@ String costToString(double cost) {
   } else {
     return "~$cost원";
   }
+}
+
+int getIndexOfCost(double cost) {
+  return costs.indexOf(cost.toInt());
+}
+
+int getCostFromSelectedList(List<bool> isSelected) {
+  for (int i = 0; i < isSelected.length; i++) {
+    if (isSelected[i] == true) {
+      return costs[i];
+    }
+  }
+  throw Exception("[ERROR] Any cost is not selected");
 }

--- a/lib/util/util_cost.dart
+++ b/lib/util/util_cost.dart
@@ -1,0 +1,11 @@
+const List<double> cost = [0.0, 500.0, 1000.0, -1.0];
+
+String costToString(double cost) {
+  if (cost == 0.0) {
+    return "무료만";
+  } else if (cost == -1.0) {
+    return "상관 없어";
+  } else {
+    return "~$cost원";
+  }
+}

--- a/lib/util/util_distance.dart
+++ b/lib/util/util_distance.dart
@@ -1,4 +1,4 @@
-const List<double> distance = [0.5, 1.0, 2.0, -1.0];
+const List<double> distances = [0.5, 1.0, 2.0, -1.0];
 
 String distanceToString(double distance) {
   if (distance == -1.0) {
@@ -6,4 +6,17 @@ String distanceToString(double distance) {
   } else {
     return "~${distance}km";
   }
+}
+
+int getIndexOfDistance(double distance) {
+  return distances.indexOf(distance);
+}
+
+double getDistanceFromSelectedList(List<bool> isSelected) {
+  for (int i = 0; i < isSelected.length; i++) {
+    if (isSelected[i] == true) {
+      return distances[i];
+    }
+  }
+  throw Exception("[ERROR] Any distance is not selected");
 }

--- a/lib/util/util_distance.dart
+++ b/lib/util/util_distance.dart
@@ -1,0 +1,9 @@
+const List<double> distance = [0.5, 1.0, 2.0, -1.0];
+
+String distanceToString(double distance) {
+  if (distance == -1.0) {
+    return "상관 없어";
+  } else {
+    return "~${distance}km";
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.9.0"
+  avatar_glow:
+    dependency: "direct main"
+    description:
+      name: avatar_glow
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -78,6 +85,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.6"
+  duration_button:
+    dependency: "direct main"
+    description:
+      name: duration_button
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   encrypt:
     dependency: transitive
     description:
@@ -130,11 +144,25 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_tts:
+    dependency: "direct main"
+    description:
+      name: flutter_tts
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.6.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
+  highlight_text:
+    dependency: "direct main"
+    description:
+      name: highlight_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.2"
   http:
     dependency: "direct main"
     description:
@@ -233,6 +261,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  localstorage:
+    dependency: "direct main"
+    description:
+      name: localstorage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0+1"
   matcher:
     dependency: transitive
     description:
@@ -246,7 +281,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
@@ -317,6 +352,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.21"
+  path_provider_ios:
+    dependency: transitive
+    description:
+      name: path_provider_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.11"
   path_provider_linux:
     dependency: transitive
     description:
@@ -324,6 +380,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.7"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -338,6 +401,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   platform:
     dependency: transitive
     description:
@@ -440,7 +510,28 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
+  speech_recognition:
+    dependency: "direct main"
+    description:
+      name: speech_recognition
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0+1"
+  speech_to_text:
+    dependency: "direct main"
+    description:
+      name: speech_to_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.2"
+  speech_to_text_platform_interface:
+    dependency: transitive
+    description:
+      name: speech_to_text_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   stack_trace:
     dependency: transitive
     description:
@@ -454,7 +545,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -475,7 +566,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.14"
+    version: "0.4.12"
+  translator:
+    dependency: "direct main"
+    description:
+      name: translator
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.7"
   typed_data:
     dependency: transitive
     description:
@@ -489,7 +587,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,14 +14,14 @@ packages:
       name: asn1lib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.4.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   avatar_glow:
     dependency: "direct main"
     description:
@@ -42,28 +42,35 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   crypto:
     dependency: transitive
     description:
@@ -105,14 +112,14 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -131,7 +138,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "1.0.4"
   flutter_rating_bar:
     dependency: "direct main"
     description:
@@ -176,21 +183,21 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.7.0"
+    version: "4.6.0"
   kakao_flutter_sdk:
     dependency: "direct main"
     description:
@@ -260,7 +267,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.1"
   localstorage:
     dependency: "direct main"
     description:
@@ -274,21 +281,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   naver_map_plugin:
     dependency: "direct main"
     description:
@@ -309,7 +316,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3+1"
+    version: "1.4.2"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -344,14 +351,14 @@ packages:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.0"
   path_provider:
     dependency: transitive
     description:
@@ -400,7 +407,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.0.7"
   pedantic:
     dependency: transitive
     description:
@@ -442,7 +449,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "6.0.4"
   shared_preferences:
     dependency: transitive
     description:
@@ -456,7 +463,7 @@ packages:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.14"
   shared_preferences_ios:
     dependency: transitive
     description:
@@ -510,7 +517,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.1"
   speech_recognition:
     dependency: "direct main"
     description:
@@ -552,21 +559,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.8"
   translator:
     dependency: "direct main"
     description:
@@ -580,21 +587,21 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.5.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -603,5 +610,5 @@ packages:
     source: hosted
     version: "0.2.0+2"
 sdks:
-  dart: ">=2.18.1 <3.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=2.16.2 <3.0.0"
+  flutter: ">=2.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: '>=2.16.2 <3.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -70,7 +70,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: 1.0.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,16 @@ dependencies:
   provider:
   flutter_rating_bar: ^4.0.1
 
+  #STT
+  speech_recognition: ^0.3.0+1
+  speech_to_text: ^4.2.2
+  highlight_text: ^0.7.2
+  avatar_glow: ^1.2.0
+  translator:
+  flutter_tts:
+  localstorage: ^4.0.0+1
+  duration_button: ^1.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### 구현 목록
- 회원가입 시 서버와 연동되어 유저 정보, 유저 선호도 저장
- 설정에서 서버와 연동되어 현재 로그인 된 유저의 선호도를 불러오고 저장
- 거리, 요금 선호도 값 변경 되는 것에 대비한 설정 페이지 쪽 코드 리팩토링

### 추가적으로 구현 필요한 목록 (자잘함)
- 회원가입 쪽 코드 리팩토링
